### PR TITLE
Fix config paths

### DIFF
--- a/docs/lindamood_ticket_sorter_v1.0.spec
+++ b/docs/lindamood_ticket_sorter_v1.0.spec
@@ -12,7 +12,7 @@ a = Analysis(
     binaries=[],
     datas=[
         ('ocr_keywords.xlsx', '.'), 
-        ('config.yaml', '.'), 
+        ('configs.yaml', '.'),
         ('template_dir/*', 'template_dir')
     ],
     hiddenimports=[],

--- a/utils/doc_config.yml
+++ b/utils/doc_config.yml
@@ -1,4 +1,4 @@
-# /lindamood_ticket_sorter_3/configs.yaml
+# /lindamood_ticket_sorter_1.0/configs.yaml
 
 input_dir: "Original Scans"
 output_dir: "processed_"


### PR DESCRIPTION
## Summary
- correct configs path in PyInstaller spec
- update doc config comment

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: pandas)*

------
https://chatgpt.com/codex/tasks/task_e_685f5c4c0490833185834b0b2f92629d