### PR TITLE
Cleanup examples folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,13 @@ See the [full guide](docs/README.md) for detailed instructions and configuration
 ## Running tests
 
 Tests are stored under `tests/`. After installing requirements, run `pytest` to ensure everything works.
+
+## Examples
+
+Example scripts are located in the `examples/` directory. The
+`paddle_demo.py` file demonstrates using PaddleOCR separately from the
+main application:
+
+```bash
+python examples/paddle_demo.py
+```

--- a/examples/working_files/t2.py
+++ b/examples/working_files/t2.py
@@ -1,5 +1,0 @@
-import os
-os.environ["KMP_DUPLICATE_LIB_OK"] = "TRUE"
-from paddleocr import PaddleOCR
-
-print("PaddleOCR import successful!")

--- a/examples/working_files/test1.py
+++ b/examples/working_files/test1.py
@@ -1,7 +1,0 @@
-import sys
-import os
-print("PYTHONPATH:", sys.path)
-print("DLL Directory:", os.environ.get("PATH", ""))
-
-import sys
-print("Running interpreter:", sys.executable)


### PR DESCRIPTION
## Summary
- document the `examples` folder in the README
- remove old experimental scripts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686ab5ffa1a48331a722f1d7d1bcef3f