### PR TITLE
Add module overview to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,18 @@ main application:
 ```bash
 python examples/paddle_demo.py
 ```
+
+## Module Overview
+
+The project is split into several small modules:
+
+- `main.py` – command line entry point that loads configuration and
+  calls the processing pipeline.
+- `gui.py` – Tkinter based GUI used for day‑to‑day operation.
+- `processor/` – core processing logic with helpers:
+  - `run.py` orchestrates batch processing and logging.
+  - `hybrid_ocr.py` performs OCR, vendor matching and export.
+  - `image_ops.py` handles image extraction and template matching.
+  - `file_handler.py` writes Excel logs and grouped output files.
+  - `filename_utils.py` parses input file names and builds output names.
+- `utils/` – configuration loading, OCR wrappers and timing utilities.

--- a/docs/README.md
+++ b/docs/README.md
@@ -113,3 +113,21 @@ OCR logic resides in `processor/hybrid_ocr.py` while image extraction and templa
 - Poppler (for PDF conversion)
 - Tesseract OCR if using the tesseract engine
 - and other packages listed in `requirements.txt`
+
+### Module Overview
+
+Below is a summary of the most important modules:
+
+- **main.py** – CLI entry point that invokes the processing pipeline.
+- **gui.py** – Tkinter GUI front end for selecting files and options.
+- **processor/run.py** – orchestrates batch processing, OCR and logging.
+- **processor/hybrid_ocr.py** – matches vendors via PaddleOCR and
+  optional template matching.
+- **processor/image_ops.py** – image extraction, orientation correction
+  and template matching helpers.
+- **processor/file_handler.py** – groups pages by vendor, writes Excel
+  logs and exports output files.
+- **processor/filename_utils.py** – parses input file names and builds
+  standardized output names.
+- **utils/** – configuration loading, OCR wrappers and timing utilities.
+


### PR DESCRIPTION
## Summary
- add a new module overview section to the main README
- include a similar section in the documentation README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68747b144d088331ad0f8bdb66b64cfe